### PR TITLE
Remove unedeed $server_name from the request

### DIFF
--- a/commands.php
+++ b/commands.php
@@ -62,7 +62,7 @@ $version = file_get_contents($docroot.'/app/version.txt');
 if (isset($_GET['pretty'])) {
     $pretty = $_GET['pretty'];
 }
-$request_uri =  "//{$server_name}{$_SERVER['REQUEST_URI']}";
+$request_uri =  "{$_SERVER['REQUEST_URI']}";
 
 $allowedCmds = array(
     'list',


### PR DESCRIPTION
The `$server_name` variable is not needed here. A relative path is enough and can prevent issues getting the correct path.